### PR TITLE
Modified _ngFireMessages  to pass on the start / end token

### DIFF
--- a/lib/pubnub-angular.js
+++ b/lib/pubnub-angular.js
@@ -55,8 +55,8 @@
             return $rootScope.$broadcast("pn-message:" + realChannel, {
               message: message,
               channel: realChannel,
-              start: messages[1],
-              end: messages[2]
+              end: messages[1],
+              start: messages[2]
             });
           });
         };

--- a/lib/pubnub-angular.js
+++ b/lib/pubnub-angular.js
@@ -50,13 +50,13 @@
         return c['_presData'] = null;
       };
       c._ngFireMessages = function(realChannel) {
-        return function(messages, t1, t2) {
+        return function(messages) {
           return c.each(messages[0], function(message) {
             return $rootScope.$broadcast("pn-message:" + realChannel, {
               message: message,
               channel: realChannel,
-              start: t1,
-              end: t2
+              start: messages[1],
+              end: messages[2]
             });
           });
         };

--- a/lib/pubnub-angular.js
+++ b/lib/pubnub-angular.js
@@ -54,7 +54,9 @@
           return c.each(messages[0], function(message) {
             return $rootScope.$broadcast("pn-message:" + realChannel, {
               message: message,
-              channel: realChannel
+              channel: realChannel,
+              start: t1,
+              end: t2
             });
           });
         };

--- a/lib/pubnub-angular.js
+++ b/lib/pubnub-angular.js
@@ -55,8 +55,8 @@
             return $rootScope.$broadcast("pn-message:" + realChannel, {
               message: message,
               channel: realChannel,
-              end: messages[1],
-              start: messages[2]
+              start: messages[1],
+              end: messages[2]
             });
           });
         };

--- a/src/pubnub-angular.coffee
+++ b/src/pubnub-angular.coffee
@@ -72,8 +72,8 @@ angular.module('pubnub.angular.service', [])
           $rootScope.$broadcast "pn-message:#{realChannel}", {
             message: message
             channel: realChannel,
-            start: messages[1],
-            end: messages[2]
+            end: messages[1],
+            start: messages[2]
           }
 
     # Internal method that creates wrappers for the message and presence event handlers. Wrappers are necessary because we want the Angular library to keep track of channels and presence events on the application's behalf.

--- a/src/pubnub-angular.coffee
+++ b/src/pubnub-angular.coffee
@@ -67,13 +67,13 @@ angular.module('pubnub.angular.service', [])
 
     # Internal method that creates a message handler for a specified channel name. Uses a closure so that we capture the channel name within the message handler callback.
     c._ngFireMessages = (realChannel) ->
-      (messages, t1, t2) ->
+      (messages) ->
         c.each messages[0], (message) ->
           $rootScope.$broadcast "pn-message:#{realChannel}", {
             message: message
             channel: realChannel,
-            start: t1,
-            end: t2
+            start: messages[1],
+            end: messages[2]
           }
 
     # Internal method that creates wrappers for the message and presence event handlers. Wrappers are necessary because we want the Angular library to keep track of channels and presence events on the application's behalf.

--- a/src/pubnub-angular.coffee
+++ b/src/pubnub-angular.coffee
@@ -72,8 +72,8 @@ angular.module('pubnub.angular.service', [])
           $rootScope.$broadcast "pn-message:#{realChannel}", {
             message: message
             channel: realChannel,
-            end: messages[1],
-            start: messages[2]
+            start: messages[1],
+            end: messages[2]
           }
 
     # Internal method that creates wrappers for the message and presence event handlers. Wrappers are necessary because we want the Angular library to keep track of channels and presence events on the application's behalf.

--- a/src/pubnub-angular.coffee
+++ b/src/pubnub-angular.coffee
@@ -71,7 +71,9 @@ angular.module('pubnub.angular.service', [])
         c.each messages[0], (message) ->
           $rootScope.$broadcast "pn-message:#{realChannel}", {
             message: message
-            channel: realChannel
+            channel: realChannel,
+            start: t1,
+            end: t2
           }
 
     # Internal method that creates wrappers for the message and presence event handlers. Wrappers are necessary because we want the Angular library to keep track of channels and presence events on the application's behalf.


### PR DESCRIPTION
We're trying to implement functionality that chunks history calls to get a large amount of history a piece at a time. We also want to implement infinite scrolling on a list that is backed by pubnub data.

It seems impossible to meet either of these use cases without knowing the end time token from the pubnub history call.

In this PR I have extended _ngFireMessages to pass on the t1, t2 tokens, in case listeners need to use them.

